### PR TITLE
New secwiki

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ WORKDIR /var/www/html
 RUN git clone https://gerrit.wikimedia.org/r/mediawiki/skins/CologneBlue  --branch ${MEDIAWIKI_BRANCH} skins/CologneBlue && \
 	git clone https://gerrit.wikimedia.org/r/mediawiki/skins/Modern  --branch ${MEDIAWIKI_BRANCH} skins/Modern  && \
 	git clone https://github.com/DaSchTour/Cavendish.git skins/Cavendish && \
+	cd skins/Cavendish && git reset --hard 0ab0042265ce45da972195d97fe3ecfb53107bc7 && cd ../../ && \
 	git clone https://gerrit.wikimedia.org/r/mediawiki/extensions/Auth_remoteuser --branch ${MEDIAWIKI_BRANCH} extensions/Auth_remoteuser
 
 # Copy settings

--- a/build/apache/openidc.conf
+++ b/build/apache/openidc.conf
@@ -6,7 +6,7 @@ OIDCClientSecret "${OIDC_CLIENT_SECRET}"
 OIDCCryptoPassphrase "${OIDC_CRYPTO_PASSPHRASE}"
 
 # RedirectURI
-OIDCRedirectURI "${SITE_URL}/callback"
+OIDCRedirectURI "/callback"
 
 # Provider info
 OIDCProviderIssuer https://auth.mozilla.auth0.com


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-764

What this PR does:
* some minor changes to the SecurityWiki Docker to both be able to build & largely stay pinned to versions & configs from https://github.com/mozilla-it/nubis-securitywiki based image
* This will replace the above repo.